### PR TITLE
Update workflow to use artifact actions v4

### DIFF
--- a/.github/workflows/verify-ec2.yml
+++ b/.github/workflows/verify-ec2.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           aws-access-key-id: ${{ secrets.SAF_AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.SAF_AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-east-1
+          aws-region: ${{ secrets.SAF_AWS_REGION }}
       - name: Check out repository
         uses: actions/checkout@v3
       - name: Clone full repository so we can push

--- a/.github/workflows/verify-ec2.yml
+++ b/.github/workflows/verify-ec2.yml
@@ -32,7 +32,7 @@ jobs:
           aws-region: ${{ secrets.SAF_AWS_REGION }}
 
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v3
       - name: Clone full repository so we can push
         run: git fetch --prune --unshallow
 

--- a/.github/workflows/verify-ec2.yml
+++ b/.github/workflows/verify-ec2.yml
@@ -82,7 +82,13 @@ jobs:
         with:
           name: ${{ github.workflow }}-${{ env.COMMIT_SHORT_SHA }}-results
           path: spec/results/
-          name: artifact-${{ matrix.suite }}
+
+      - name: Upload ${{ matrix.suite }} to Heimdall
+        if: ${{ !contains(steps.commit.outputs.message, 'only-validate-profile') }}
+        continue-on-error: true
+        run: |
+          curl -# -s -F data=@spec/results/${{ env.PLATFORM }}_${{ matrix.suite }}.json -F "filename=${{ env.COMMIT_SHORT_SHA }}-${{ env.PLATFORM }}_${{ matrix.suite }}" -F "public=true" -F "evaluationTags=${{ env.COMMIT_SHORT_SHA }},${{ github.repository }},${{ github.workflow }}" -H "Authorization: Api-Key ${{ secrets.HEIMDALL_UPLOAD_GROUP_KEY }}" "${{ vars.SAF_HEIMDALL_URL }}/evaluations"
+
       - name: Display our ${{ matrix.suite }} results summary
         if: ${{ !contains(steps.commit.outputs.message, 'only-validate-profile') }}
         uses: mitre/saf_action@v1.5.0

--- a/.github/workflows/verify-ec2.yml
+++ b/.github/workflows/verify-ec2.yml
@@ -82,6 +82,7 @@ jobs:
         with:
           name: ${{ github.workflow }}-${{ env.COMMIT_SHORT_SHA }}-results
           path: spec/results/
+          name: artifact-${{ matrix.suite }}
           overwrite: true
       - name: Display our ${{ matrix.suite }} results summary
         if: ${{ !contains(steps.commit.outputs.message, 'only-validate-profile') }}

--- a/.github/workflows/verify-ec2.yml
+++ b/.github/workflows/verify-ec2.yml
@@ -15,10 +15,10 @@ jobs:
       CHEF_LICENSE_KEY: ${{ secrets.SAF_CHEF_LICENSE_KEY }}
       KITCHEN_LOCAL_YAML: kitchen.ec2.yml
       PLATFORM: 'rhel-8'
-      LC_ALL: "en_US.UTF-8"
+      LC_ALL: 'en_US.UTF-8'
     strategy:
       matrix:
-        suite: ["vanilla", "hardened"]
+        suite: ['vanilla', 'hardened']
       fail-fast: false
     steps:
       - name: add needed packages
@@ -33,7 +33,6 @@ jobs:
 
       - name: Check out repository
         uses: actions/checkout@v4
-
       - name: Clone full repository so we can push
         run: git fetch --prune --unshallow
 
@@ -53,7 +52,7 @@ jobs:
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "3.1"
+          ruby-version: '3.1'
 
       - name: Disable ri and rdoc
         run: 'echo "gem: --no-ri --no-rdoc" >> ~/.gemrc'
@@ -77,11 +76,10 @@ jobs:
         if: ${{ !contains(steps.commit.outputs.message, 'only-validate-profile') }}
         uses: mitre/saf_action@v1.5.0
         with:
-          command_string: "view summary -j -i spec/results/${{ env.PLATFORM }}_${{ matrix.suite }}.json -o spec/results/${{ env.PLATFORM }}_${{ matrix.suite }}-data.json"
+          command_string: 'view summary -j -i spec/results/${{ env.PLATFORM }}_${{ matrix.suite }}.json -o spec/results/${{ env.PLATFORM }}_${{ matrix.suite }}-data.json'
 
       - name: Save Test Result JSON
-        if: ${{ !contains(steps.commit.outputs.message, 'only-validate-profile') }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ github.workflow }}-${{ env.COMMIT_SHORT_SHA }}-results
           path: spec/results/
@@ -96,7 +94,7 @@ jobs:
         if: ${{ !contains(steps.commit.outputs.message, 'only-validate-profile') }}
         uses: mitre/saf_action@v1.5.0
         with:
-          command_string: "view summary -i spec/results/${{ env.PLATFORM }}_${{ matrix.suite }}.json"
+          command_string: 'view summary -i spec/results/${{ env.PLATFORM }}_${{ matrix.suite }}.json'
 
       - name: Generate Markdown Summary
         continue-on-error: true
@@ -109,4 +107,4 @@ jobs:
         if: ${{ !contains(steps.commit.outputs.message, 'only-validate-profile') }}
         uses: mitre/saf_action@v1.5.0
         with:
-          command_string: "validate threshold -i spec/results/${{ env.PLATFORM }}_${{ matrix.suite }}.json -F ${{ matrix.suite }}.threshold.yml"
+          command_string: 'validate threshold -i spec/results/${{ env.PLATFORM }}_${{ matrix.suite }}.json -F ${{ matrix.suite }}.threshold.yml'

--- a/.github/workflows/verify-ec2.yml
+++ b/.github/workflows/verify-ec2.yml
@@ -83,7 +83,6 @@ jobs:
           name: ${{ github.workflow }}-${{ env.COMMIT_SHORT_SHA }}-results
           path: spec/results/
           name: artifact-${{ matrix.suite }}
-          overwrite: true
       - name: Display our ${{ matrix.suite }} results summary
         if: ${{ !contains(steps.commit.outputs.message, 'only-validate-profile') }}
         uses: mitre/saf_action@v1.5.0

--- a/.github/workflows/verify-ec2.yml
+++ b/.github/workflows/verify-ec2.yml
@@ -82,13 +82,7 @@ jobs:
         with:
           name: ${{ github.workflow }}-${{ env.COMMIT_SHORT_SHA }}-results
           path: spec/results/
-
-      - name: Upload ${{ matrix.suite }} to Heimdall
-        if: ${{ !contains(steps.commit.outputs.message, 'only-validate-profile') }}
-        continue-on-error: true
-        run: |
-          curl -# -s -F data=@spec/results/${{ env.PLATFORM }}_${{ matrix.suite }}.json -F "filename=${{ env.COMMIT_SHORT_SHA }}-${{ env.PLATFORM }}_${{ matrix.suite }}" -F "public=true" -F "evaluationTags=${{ env.COMMIT_SHORT_SHA }},${{ github.repository }},${{ github.workflow }}" -H "Authorization: Api-Key ${{ secrets.HEIMDALL_UPLOAD_GROUP_KEY }}" "${{ vars.SAF_HEIMDALL_URL }}/evaluations"
-
+          overwrite: true
       - name: Display our ${{ matrix.suite }} results summary
         if: ${{ !contains(steps.commit.outputs.message, 'only-validate-profile') }}
         uses: mitre/saf_action@v1.5.0

--- a/.github/workflows/verify-ec2.yml
+++ b/.github/workflows/verify-ec2.yml
@@ -31,7 +31,7 @@ jobs:
           aws-secret-access-key: ${{ secrets.SAF_AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ secrets.SAF_AWS_REGION }}
       - name: Check out repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Clone full repository so we can push
         run: git fetch --prune --unshallow
 
@@ -78,6 +78,7 @@ jobs:
           command_string: 'view summary -j -i spec/results/${{ env.PLATFORM }}_${{ matrix.suite }}.json -o spec/results/${{ env.PLATFORM }}_${{ matrix.suite }}-data.json'
 
       - name: Save Test Result JSON
+        if: ${{ !contains(steps.commit.outputs.message, 'only-validate-profile') }}
         uses: actions/upload-artifact@v4
         with:
           name: ${{ github.workflow }}-${{ env.COMMIT_SHORT_SHA }}-results

--- a/.github/workflows/verify-ec2.yml
+++ b/.github/workflows/verify-ec2.yml
@@ -27,10 +27,9 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ${{ secrets.SAF_AWS_REGION }}
-
+          aws-access-key-id: ${{ secrets.SAF_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.SAF_AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
       - name: Check out repository
         uses: actions/checkout@v3
       - name: Clone full repository so we can push


### PR DESCRIPTION
Changes made:
- Updating artifact actions v3 to v4 since v3 will be deprecated 1/30/2025
- Prepended GitHub secrets with `SAF_` since those have changed